### PR TITLE
varops-budget, script-restoration: update varops cost model, update benchmark section, fix incorrect specifications and fix language

### DIFF
--- a/bip-unknown-script-restoration.mediawiki
+++ b/bip-unknown-script-restoration.mediawiki
@@ -15,7 +15,7 @@
 
 ===Abstract===
 
-This new BIP introduces a new tapleaf version (0xc2) which restores Bitcoin script to its pre-0.3.1 capability, relying on the Varops Budget in [[bip-unknown-varops-budget.mediawiki|BIP-varops]] to prevent the excessive computational time which caused CVE-2010-5137.
+This BIP introduces a new tapleaf version (0xc2) which restores Bitcoin script to its pre-0.3.1 capability, relying on the Varops Budget in [[bip-unknown-varops-budget.mediawiki|BIP-varops]] to prevent the excessive computational time which caused CVE-2010-5137.
 
 In particular, this BIP:
 - Reenables disabled opcodes.
@@ -51,9 +51,9 @@ There needs to be some limit on memory usage, to avoid a memory-based denial of 
 
 Putting the entire transaction on the stack is a foreseeable use case, hence using the block size (4MB) as a limit makes sense.  However, allowing 4MB stack elements is a significant increase in memory requirements, so a total limit of twice that many bytes (8MB) is introduced.  Many stack operations require making at least one copy, so this allows such use.
 
-Putting all outputs or inputs from the transaction on the stack as separate elements requires as much stack capacity as there are inputs or outputs.  The smallest possible input is 34 bytes (allowing almost 26411 inputs), and the smallest possible output is 9 bytes (allowing almost 111111 inputs).  However, empty outputs are rare and not economically interesting.  Thus we consider smallest non-OP_RETURN standard output script, which is P2WPKH at 22 bytes, giving a minimum output size of 31 bytes, allowing 32258 outputs in a maximally-sized transaction.
+Putting all outputs or inputs from the transaction on the stack as separate elements requires as much stack capacity as there are inputs or outputs.  The smallest possible input is 34 bytes (allowing almost 26,411 inputs), and the smallest possible output is 9 bytes (allowing almost 111,111 outputs).  However, empty outputs are rare and not economically interesting.  Thus we consider smallest non-OP_RETURN standard output script, which is P2WPKH at 22 bytes, giving a minimum output size of 31 bytes, allowing 32,258 outputs in a maximally-sized transaction.
 
-This makes 32768 a reasonable upper limit for stack elements.
+This makes 32,768 a reasonable upper limit for stack elements.
 
 ===SUCCESS Opcodes===
 
@@ -97,9 +97,9 @@ Now:
 
 ===Enabled Opcodes===
 
-Fifteen opcodes which were removed in v0.3.1 are re-enabled in v2 Tapscript.
+Fifteen opcodes that were removed in v0.3.1 are re-enabled in v2 Tapscript.
 
-If there are less than the required number of stack elements, these opcodes fail validation.  Equivalently, a requirement to pop off the stack which cannot be satisfied causes the opcode to fail validation.
+If there are fewer than the required number of stack elements, these opcodes fail validation.  Equivalently, a requirement to pop off the stack which cannot be satisfied causes the opcode to fail validation.
 
 See [[bip-unknown-varops-budget.mediawiki|BIP-varops]] for the meaning of the annotations in the varops cost field.
 
@@ -116,7 +116,7 @@ See [[bip-unknown-varops-budget.mediawiki|BIP-varops]] for the meaning of the an
 |OP_CAT
 |126
 |2
-|length(A) + length(B)
+|(length(A) + length(B)) * 3
 |COPYING
 |
 # Pop B off the stack.
@@ -127,20 +127,20 @@ See [[bip-unknown-varops-budget.mediawiki|BIP-varops]] for the meaning of the an
 |OP_SUBSTR
 |127
 |3
-|length(LEN) + length(BEGIN) + MIN(Value of LEN, length(A) - Value of BEGIN, 0)
+|(length(LEN) + length(BEGIN)) * 2 + MIN(Value of LEN, MAX(length(A) - Value of BEGIN, 0)) * 3
 |LENGTHCONV + COPYING
 |
 # Pop LEN off the stack.
 # Pop BEGIN off the stack.
 # Pop A off the stack.
-# Remove BEGIN bytes from the front of A (all bytes if BEGIN greater than length of A).
+# Remove BEGIN bytes from the front of A (all bytes if BEGIN is greater than length of A).
 # If length(A) is greater than value(LEN), truncate A to length value(LEN).
 # Push A onto the stack.
 |-
 |OP_LEFT
 |128
 |2
-|length(OFFSET)
+|length(OFFSET) * 2
 |LENGTHCONV
 |
 # Pop OFFSET off the stack.
@@ -151,7 +151,7 @@ See [[bip-unknown-varops-budget.mediawiki|BIP-varops]] for the meaning of the an
 |OP_RIGHT
 |129
 |2
-|length(OFFSET) + value of OFFSET
+|length(OFFSET) * 2 + value of OFFSET * 3
 |LENGTHCONV + COPYING
 |
 # Pop OFFSET off the stack.
@@ -181,7 +181,7 @@ OP_LEFT only needs to read its OFFSET operand (truncation is free), whereas OP_R
 |OP_INVERT
 |131
 |1
-|length(A) * 2
+|length(A) * 4
 |OTHER
 |
 # Pop A off the stack.
@@ -191,7 +191,7 @@ OP_LEFT only needs to read its OFFSET operand (truncation is free), whereas OP_R
 |OP_AND
 |132
 |2
-|length(A) + length(B)
+|(length(A) + length(B)) * 2
 |OTHER + ZEROING
 |
 # Pop B off the stack.
@@ -203,7 +203,7 @@ OP_LEFT only needs to read its OFFSET operand (truncation is free), whereas OP_R
 |OP_OR
 |133
 |2
-|MIN(length(A), length(B)) * 2
+|MIN(length(A), length(B)) * 4
 |OTHER
 |
 # Pop B off the stack.
@@ -215,7 +215,7 @@ OP_LEFT only needs to read its OFFSET operand (truncation is free), whereas OP_R
 |OP_XOR
 |134
 |2
-|MIN(length(A), length(B)) * 2
+|MIN(length(A), length(B)) * 4
 |OTHER
 |
 # Pop B off the stack.
@@ -244,7 +244,7 @@ Note that these are raw bitshifts, unlike the sign-preserving arithmetic shifts 
 |OP_UPSHIFT
 |152
 |2
-|length(BITS) + (Value of BITS) / 8 + length(A).  If BITS % 8 != 0, add length(A) * 2
+|length(BITS) * 2 + (Value of BITS) / 8 * 2 + length(A) * 3.  If BITS % 8 != 0, add length(A) * 4
 |LENGTHCONV + ZEROING + COPYING. If BITS % 8 != 0, + OTHER.
 |
 # Pop BITS off the stack.
@@ -257,14 +257,14 @@ Note that these are raw bitshifts, unlike the sign-preserving arithmetic shifts 
 |OP_DOWNSHIFT
 |153
 |2
-|length(BITS) + MAX((length(A) - (Value of BITS) / 8), 0) * 2
-|LENGTHCONV + OTHER
+|length(BITS) * 2 + MAX((length(A) - (Value of BITS) / 8), 0) * 3
+|LENGTHCONV + COPYING
 |
 # Pop BITS off the stack.
 # Pop A off the stack.
 # For BITOFF from 0 to (length(A)-1) * 8 - value(BITS):
     # Copy each bit in A from BITOFF + value(BITS) to BITOFF.
-# Truncate A to remove value(OFF) bytes (or all, if value(OFF) > length(A)).
+# Truncate A to remove value(BITS) / 8 bytes from the end (or all bytes, if value(BITS) / 8 > length(A)).
 # Push A onto the stack.
 |}
 
@@ -276,7 +276,7 @@ UPSHIFT also needs to read BITS.  In general, it may need to reallocate (copying
 
 OP_UPSHIFT can produce huge results, and so must be checked for limits prior to evaluation.  It is also carefully defined to avoid reallocating twice (reallocating to prepend bytes, then again to append a single byte) which has the practical advantage of being able to share the same downward bitshift routine as OP_DOWNSHIFT.
 
-====Multiply and Divide Opcodes===
+====Multiply and Divide Opcodes====
 
 {|
 ! Opcode
@@ -289,7 +289,7 @@ OP_UPSHIFT can produce huge results, and so must be checked for limits prior to 
 |OP_2MUL
 |141
 |1
-|length(A) * 3
+|length(A) * 7
 |OTHER + COPYING
 |
 # Pop A off the stack.
@@ -301,18 +301,18 @@ OP_UPSHIFT can produce huge results, and so must be checked for limits prior to 
 |OP_2DIV
 |142
 |1
-|length(A) * 2
+|length(A) * 4
 |OTHER
 |
 # Pop A off the stack.
 # Shift each byte 1 bit to the right (decreasing values, equivalent to C's >> operator), tracking the last non-zero value.
 # Truncate A at the last non-zero byte.
 # Push A onto the stack.
-|--
+|-
 |OP_MUL
 |149
 |2
-|length(A) + length(B) + (length(A) + 7) / 8 * length(B) * 6  (BEWARE OVERFLOW)
+|(length(A) + length(B)) * 3 + (length(A) + 7) / 8 * length(B) * 27  (BEWARE OVERFLOW)
 |See Appendix
 |
 # Pop B off the stack.
@@ -326,7 +326,7 @@ OP_UPSHIFT can produce huge results, and so must be checked for limits prior to 
 |OP_DIV
 |150
 |2
-|length(A) * 9 + length(B) * 2 + length(A)^2 / 3  (BEWARE OVERFLOW)
+|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW)
 |See Appendix
 |
 # Pop B off the stack.
@@ -340,9 +340,11 @@ OP_UPSHIFT can produce huge results, and so must be checked for limits prior to 
 |OP_MOD
 |151
 |2
-|length(A) * 9 + length(B) * 2 + length(A)^2 / 3  (BEWARE OVERFLOW)
+|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW)
 |See Appendix
 |
+# Pop B off the stack.
+# Pop A off the stack.
 # Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
 # If B is empty or all zeroes, fail.
 # Perform division as per Knuth's The Art of Computer Programming v2 page 272, Algorithm D "Division of non-negative integers".
@@ -375,7 +377,7 @@ The opcodes OP_ADD, OP_SUB, OP_1ADD and OP_1SUB are redefined in v2 Tapscript to
 |OP_ADD
 |147
 |2
-|MAX(length(A), length(B)) * 4
+|MAX(length(A), length(B)) * 9
 |ARITH + COPYING
 |
 # Pop B off the stack.
@@ -390,7 +392,7 @@ The opcodes OP_ADD, OP_SUB, OP_1ADD and OP_1SUB are redefined in v2 Tapscript to
 |OP_1ADD
 |139
 |1
-|MAX(1, length(A)) * 4
+|MAX(1, length(A)) * 9
 |ARITH + COPYING
 |
 # Pop A off the stack.
@@ -399,19 +401,19 @@ The opcodes OP_ADD, OP_SUB, OP_1ADD and OP_1SUB are redefined in v2 Tapscript to
 |OP_SUB
 |148
 |2
-|MAX(length(A), length(B)) * 3
+|MAX(length(A), length(B)) * 6
 |ARITH
 |
 # Pop B off the stack.
 # Pop A off the stack.
 # For each byte in B, subtract it and previous underflow from the equivalent byte in A, remembering next underflow.
-# If there was final overflow, fail validation.
+# If there was final underflow, fail validation.
 # Remember last non-zero byte written into A, and truncate A after that point.
 |-
 |OP_1SUB
-|140	
+|140
 |1
-|MAX(1, length(A)) * 3
+|MAX(1, length(A)) * 6
 |ARITH
 |
 # Pop A off the stack.
@@ -420,7 +422,7 @@ The opcodes OP_ADD, OP_SUB, OP_1ADD and OP_1SUB are redefined in v2 Tapscript to
 
 ====Rationale====
 
-Note the basic cost for ADD is three times the maximum operand length, but then considers the case where a reallocation and copy needs to occur to append the final carry byte (COPYING, which costs 1 unit per byte).
+Note that the basic cost for ADD is six times the maximum operand length (ARITH), but then considers the case where a reallocation and copy needs to occur to append the final carry byte (COPYING, which costs 3 units per byte).
 
 Subtraction is cheaper because underflow does not occur: that is a validation failure, as mathematicians agree the result would not be natural.
 
@@ -434,23 +436,23 @@ The following opcodes have costs below:
 ! Varops Reason
 |-
 | OP_CHECKLOCKTIMEVERIFY
-| Length of operand
+| Length of operand * 2
 | LENGTHCONV
 |-
 | OP_CHECKSEQUENCEVERIFY
-| Length of operand
+| Length of operand * 2
 | LENGTHCONV
 |-
 | OP_CHECKSIGADD
-| MAX(1, length(number operand)) * 4 + 26000
+| MAX(1, length(number operand)) * 9 + 500,000
 | ARITH + COPYING + SIGCHECK
 |-
 | OP_CHECKSIG
-| 26000
+| 500,000
 | SIGCHECK
 |-
 | OP_CHECKSIGVERIFY
-| 26000
+| 500,000
 | SIGCHECK
 |}
 
@@ -513,7 +515,7 @@ To be clear, the following operations are arithmetic and will normalize their re
 
 ==Backwards compatibility==
 
-This BIP defines a previous unused (and thus, always-successful) tapscript version, for backwards compatibility.
+This BIP defines a previously unused (and thus, always-successful) tapscript version, for backwards compatibility.
 
 ==Reference Implementation==
 
@@ -538,17 +540,19 @@ In alphabetical order:
 
 Multiplication and division require multiple passes over the operands, meaning a cost proportional to the square of the lengths involved, and the word size used for that iteration makes a difference.  We assume 8 bytes (64 bits) at a time are evaluated, and the ability to multiply two 64-bit numbers and receive a 128-bit result, and divide a 128-bit number by a 64 bit number to receive a 128 bit quotient and remainder.  This is true on modern 64-bit CPUs (sometimes using multiple instructions).
 
-===Multiplication Cost====
+===Multiplication Cost===
 
 For multiplication, the steps break down like so:
-1. Allocate and zero the result: cost = length(A) + length(B) (ZEROING)
+1. Allocate and zero the result: cost = (length(A) + length(B)) * 2 (ZEROING)
 2. For each word in A:
-  * Multiply by each word in B, into a scratch vector: cost = 3 * length(B) (ARITH)
-  * Sum scratch vector at the word offset into the result: cost = 3 * length(B) (ARITH)
+  * Multiply by each word in B, into a scratch vector: cost = 6 * length(B) (ARITH)
+  * Sum scratch vector at the word offset into the result: cost = 6 * length(B) (ARITH)
 
-Note: we do not assume Karatsuba, Tom-Cooke or other optimizations.
+Note: we do not assume Karatsuba, Toom-Cook or other optimizations.
 
-This results in a cost of: length(A) + length(B) + (length(A) + 7) / 8 * length(B) * 6.
+The theoretical cost is: (length(A) + length(B)) * 2 + (length(A) + 7) / 8 * length(B) * 12.
+
+However, benchmarking reveals that the inner loop overhead (branch misprediction, cache effects on small elements) is undercosted by the theoretical model.  A 2.25× multiplier on the quadratic term accounts for this, giving a cost of: (length(A) + length(B)) * 3 + (length(A) + 7) / 8 * length(B) * 27.
 
 This is slightly asymmetric: in practice an implementation usually finds that CPU pipelining means choosing B as the larger operand is optimal.
 
@@ -556,30 +560,30 @@ This is slightly asymmetric: in practice an implementation usually finds that CP
 
 For division, the steps break down like so:
 
-1. Bit shift both operands to set top bit of B (OP_UPSHIFT, without overflow for B): cost = length(A) * 3 + length(B) * 2
+1. Bit shift both operands to set top bit of B (OP_UPSHIFT, without overflow for B): cost = length(A) * 6 + length(B) * 4
 
 2. Trim trailing bytes.  This costs according to the number of byte removed, but since that is subtractive on future costs, we ignore it.
 
 3. If B is longer, the answer is 0 already.  So assume A is longer from now on (or equal length).
 
-4. Compare: cost = length(A) (COMPARING)
+4. Compare: cost = length(A) * 2 (COMPARING)
 
-5. Subtract: cost = length(A) * 3 (ARITH)
+5. Subtract: cost = length(A) * 6 (ARITH)
 
 6. for (length(A) - NormalizedLength(B)) in words:
-   1. Multiply word by B -> scratch: cost = NormalizedLength(B) * 3 (ARITH)
-   2. Subtract scratch from A: cost = length(A) * 3 (ARITH)
-   3. Add B into A (no overflow): cost = length(A) * 3 (ARITH)
+   1. Multiply word by B -> scratch: cost = NormalizedLength(B) * 6 (ARITH)
+   2. Subtract scratch from A: cost = length(A) * 6 (ARITH)
+   3. Add B into A (no overflow): cost = length(A) * 6 (ARITH)
    4. Shrink A by 1 word.
 
-7. OP_MOD: shift A down, trim trailing zeros: cost = length(A) * 2
+7. OP_MOD: shift A down, trim trailing zeroes: cost = length(A) * 4
 
-8. OP_DIV: trim trailing zeros: cost = length(A) * 2
+8. OP_DIV: trim trailing zeros: cost = length(A) * 4
 
-Note that the loop at step 6 shrinks A every time, so the *average* cost of each iteration is (NormalizedLength(B) * 3 + length(A) * 6) / 2.  The cost of step 6 is:
+Note that the loop at step 6 shrinks A every time, so the *average* cost of each iteration is (NormalizedLength(B) * 6 + length(A) * 12) / 2.  The cost of step 6 is:
 
-	(length(A) - NormalizedLength(B)) / 8 * (NormalizedLength(B) * 3 + length(A) * 6) / 2
+	(length(A) - NormalizedLength(B)) / 8 * (NormalizedLength(B) * 6 + length(A) * 12) / 2
 
-The worst case here is when NormalizedLength(B) is 0: length(A) * length(A) / 3.
+The worst case is when NormalizedLength(B) is 0: length(A) * length(A) * 2 / 3.
 
-The cost for all the steps in either case is: length(A) * 9 + length(B) * 2 + length(A) * length(A) / 3.
+The cost for all the steps is: length(A) * 18 + length(B) * 4 + length(A) * length(A) * 2 / 3.

--- a/bip-unknown-varops-budget.mediawiki
+++ b/bip-unknown-varops-budget.mediawiki
@@ -15,7 +15,7 @@
 
 ===Abstract===
 
-This new BIP defines a "varops budget", which generalizes the "sigops budget" introduced in [[bip-0342.mediawiki|BIP342]] to non-signature operations.
+This BIP defines a "varops budget", which generalizes the "sigops budget" introduced in [[bip-0342.mediawiki|BIP342]] to non-signature operations.
 
 This BIP is a useful framework for other BIPs to draw upon, and provides opcode examples which are always less restrictive than current rules.
 
@@ -33,7 +33,7 @@ This BIP introduces a simple, systematic and explicit cost framework for evaluat
 
 ===A Model For Opcodes Dealing With Stack Data===
 
-Without an explicit and low limit on the size of stack operands, the bottleneck for script operations is based on the time taken to process the stack data it accesses (the exceptions being signature operations).  The cost model uses the length of the stack inputs (or occasionally, outputs), hence the term "varops".
+Without an explicit and low limit on the size of stack operands, the bottleneck for script operations is based on the time taken to process the stack data it accesses (with the exception of signature operations).  The cost model uses the length of the stack inputs (or occasionally, outputs), hence the term "varops".
 
 - We assume that the manipulation of the stack vector itself (e.g. OP_DROP) is negligible (with the exception of OP_ROLL)
 - We assume that memory allocation and deallocation overhead is negligible.
@@ -47,7 +47,7 @@ The last two assumptions make a large difference in practice: normal usage on sm
 
 ==Design==
 
-A per-transaction integer "varops budget" is determined by multiplying the total transaction weight by the fixed factor 5,200<ref>As the most expensive non-signature operation (SHA256 hashing) is 10 varops per byte, and the largest previously-allowed stack element size is 520, it is trivial to demonstrate that no non-signature operation previously allows can violate the varops budget, as the weight of the opcode itself provides 5200 budget).</ref>.  The budget is transaction-wide (rather than per-input) to allow for cross-input introspection: a small input may reasonably access larger inputs.
+A per-transaction integer "varops budget" is determined by multiplying the total transaction weight by the fixed factor 10,000 (chosen to make operation costs all integer values). The budget is transaction-wide (rather than per-input) to allow for cross-input introspection: a small input may reasonably access larger inputs.
 
 Opcodes consume budget as they are executed, based on the length (not generally the value) of their parameters as detailed below.  A transaction which exceeds its budget fails to validate.
 
@@ -58,96 +58,81 @@ The costs of opcodes were determined by benchmarking on a variety of platforms.
 As each block can contain 80,000 Schnorr signature checks, we used this as a reasonable upper bound for maximally slow block processing.
 
 To estimate a conservative maximum runtime for each opcode, we consider scripts with two constraints:
-# thescript size is limited by the existing weight limit of 4,000,000 units and
-# the script can only consume the varops budget of a whole block: 5,200 * 4,000,000 (~21b).
+1. the script size is limited by the existing weight limit of 4,000,000 units and
+2. the script can only consume the varops budget of a whole block: 10,000 * 4,000,000 (40b).
 
 The script is assumed to execute in a single thread and acts on initial stack elements that are not included in the limits for conservatism.
 
 Ideally, on each platform we tested, the worst case time for each opcode would be no worse than the Schnorr signature upper bound: i.e. the block would get no slower.  And while CHECKSIG can be batched and/or done in parallel, it also involves hashing, which is not taken into account here (the worst-case being significantly slower than the signature validations themselves).
 
-The signature cost is simply carried across from the existing [[bip-0342.mediawiki||BIP-342]] limit: 50 weight units allows you one signature.  Since each transaction gets varops budget for the entire transaction (not just the current input's witness), and each input has at least 40 bytes (160 weight), this is actually slightly more generous than the sigops budget (which was 50 + witness weight), but still limits the entire block to 80,000 signatures.
+The signature cost is simply carried across from the existing [[bip-0342.mediawiki|BIP-342]] limit: 50 weight units allow you one signature.  Since each transaction gets varops budget for the entire transaction (not just the current input's witness), and each input has at least 40 bytes (160 weight), this is actually slightly more generous than the sigops budget (which was 50 + witness weight), but still limits the entire block to 80,000 signatures.
 
 ===Benchmarks===
 
-{|
-! Machine
-! OS
-! Compiler
-! Worst-case script
-! Worst-case time
-! Worst-case Schnorr eq
-|-
-| AMD Ryzen 5 3600
-| Linux
-| gcc
-| MUL_DUP_520Bx2
-| 2.30 s
-| 60261
-|-
-| Intel i5-12500
-| Linux
-| gcc
-| MUL_DUP_520Bx2
-| 2.07 s
-| 82963
-|-
-| Intel i7-7700
-| Linux
-| gcc
-| HASH256_DROP_DUP_10KBx2
-| 4.73 s
-| 128598
-|-
-| Apple M4 Pro
-| macOS
-| clang
-| RIPEMD160_DROP_DUP_520Bx2
-| 1.18 s
-| 83382
-|}
+The costs were validated by constructing maximally expensive scripts for every opcode (filling a full block with worst-case operands) and measuring wall-clock execution time across 14 machines spanning x86_64, ARM64, Linux, macOS, and Windows:
 
-We are looking for more benchmarks, so please contribute with your machine by checking out https://github.com/jmoik/bitcoin/tree/gsr and running ./build/bin/bench_varops --epochs 5 --file data.csv
+Apple M1 Pro, Apple M2, Apple M4 Pro (macOS + Linux/Docker), AMD Ryzen 5 3600, AMD Ryzen 7 5800U, AMD Ryzen 9 9950X, Intel i5-12500, Intel i7-7700, Intel i7-8700, Intel i9-9900K, Intel N150 (Umbrel), Raspberry Pi 5.
+
+For each machine, the ratio of the GSR worst-case block time to the existing (pre-GSR) worst-case block time was computed.  A ratio below 1.0 means GSR does not introduce a new worst case.  On all 14 tested machines, the ratio is below 1.0.
+
+Without GSR, the slowest blocks are dominated by:
+* Schnorr signature validation (80,000 signatures per block)
+* Repeated hashing of 520-byte elements (3DUP + HASH256, 3DUP + RIPEMD160)
+
+With GSR enabled, the slowest blocks restricted by the varops budget depend on the machine but usually include:
+* Schnorr signature validation (80,000 signatures per block)
+* Repeated hashing of 520-byte elements (3DUP + HASH256, 3DUP + RIPEMD160)
+* Small-element multiplication (MUL on 1-byte operands)
+* Large-element left-shift with copying (2DUP + LSHIFT on 10KB elements)
+* Hashing of 1KB elements (HASH256)
+* Stack rolling at maximum depth (ROLL)
+* Large-element copying (TUCK, CAT on 100KB–2MB elements)
+
+The raw benchmark data, analysis scripts, and visualized results are available at https://github.com/jmoik/varopsData. This repository also provides instructions for running the benchmarks on your own machine.
+
 
 ===Cost Categories===
 
-We divided operations into five speed categories:
+We divided operations into six speed categories:
 
-# Signature operations. 
-# SHA256 operations.
-# OP_ROLL, which does a large-scale stack movement.
-# Fast operations: comparing bytes, comparing bytes against zero, copying bytes and zeroing bytes.  Empirically, these have been shown to be well-optimized.
-# Everything else.
+1. Signature operations.
+2. Hashing operations.
+3. OP_ROLL, which does a large-scale stack movement.
+4. Fast operations: comparing bytes, comparing bytes against zero, and zeroing bytes.  Empirically, these have been shown to be well-optimized.
+5. Copying bytes: slightly more expensive than fast operations due to memory allocation overhead.
+6. Everything else.
 
 Each class then has the following costs.
 
-# Signature operations cost 260,000 (5,200 * 50) units each.
-# Hashing costs 10 units per byte hashed.
-# OP_ROLL costs an additional 24 units per stack entry moved (i.e. the value of its operand).
-# Fast operations cost 1 unit per byte output.
-# Other operations cost 2 units per byte output.
+1. Signature operations cost 500,000 (10,000 * 50) units each, this resembles the cost of the existing sigops budget.
+2. Hashing costs 50 units per byte hashed.
+3. OP_ROLL costs an additional 48 units (24 bytes per std::vector * 2 units per byte) per stack entry moved (i.e. the value of its operand).
+4. Fast operations cost 2 units per byte output.
+5. Copying operations cost 3 units per byte output.
+6. Other operations cost 4 units per byte output.
 
 ===Variable Opcode Budget===
 
 We use the following annotations to indicate the derivation for each opcode:
 
 ;COMPARING
-: Comparing two objects: cost = 1 per byte compared.
+: Comparing two objects: cost = 2 per byte compared.
 ;COMPARINGZERO
-: Comparing an object against zeroes: cost = 1 per byte compared.
+: Comparing an object against zeroes: cost = 2 per byte compared.
 ;ZEROING
-: Zeroing out bytes: cost = 1 per byte zeroed
+: Zeroing out bytes: cost = 2 per byte zeroed.
 ;COPYING
-: Copying bytes: cost = 1 per byte copied.
+: Copying bytes: cost = 3 per byte copied.
 ;LENGTHCONV
-: Converting an operand to a length value, including verifying that trailing bytes are zero: cost = 1 per byte copied.
+: Converting an operand to a length value, including verifying that trailing bytes are zero: cost = 2 per byte examined.
 ;SIGCHECK
-: Checking a signature is a flat cost: cost = 260,000.
+: Checking a signature is a flat cost: cost = 500,000.
 ;HASH
-: cost = 10 per byte hashed.
+: cost = 50 per byte hashed.
 ;ROLL
-: cost = 24 per stack element moved.
+: cost = 48 per stack element moved.
 ;OTHER
-: all other operations which take a variable-length parameter: cost = 2 per byte written.
+: all other operations which take a variable-length parameter: cost = 4 per byte written.
 
 Note that COMPARINGZERO is a subset of COMPARING: an implementation must examine every byte of a stack element to determine if the value is 0.  This can be done efficiently using existing comparison techniques, e.g. check the first byte, then `memcmp(first, first+1, len-1)`.
 
@@ -167,23 +152,23 @@ The following opcodes demonstrate the approach, with an analysis of how the cost
 ! Reason
 |-
 |OP_VERIFY
-|length(A)
+|length(A) * 2
 |COMPARINGZERO
 |-
 |OP_NOT
-|length(A)
+|length(A) * 2
 |COMPARINGZERO
 |-
 |OP_0NOTEQUAL
-|length(A)
+|length(A) * 2
 |COMPARINGZERO
 |-
 |OP_EQUAL
-|If length(A) != length(B): 0, otherwise length(A)
+|If length(A) != length(B): 0, otherwise length(A) * 2
 |COMPARING
 |-
 |OP_EQUALVERIFY
-|If length(A) != length(B): 0, otherwise length(A)
+|If length(A) != length(B): 0, otherwise length(A) * 2
 |COMPARING
 |}
 
@@ -201,48 +186,48 @@ OP_EQUAL and OP_EQUALVERIFY don't have to examine any data (and the Bitcoin Core
 ! Reason
 |-
 |OP_2DUP
-|length(A) + length(B)
+|(length(A) + length(B)) * 3
 |COPYING
 |-
 |OP_3DUP
-|length(A) + length(B) + length(C)
+|(length(A) + length(B) + length(C)) * 3
 |COPYING
 |-
 |OP_2OVER
-|length(C) + length(D)
+|(length(C) + length(D)) * 3
 |COPYING
 |-
 |OP_IFDUP
-|length(A) * 2
+|length(A) * 5
 |COMPARINGZERO + COPYING
 |-
 |OP_DUP
-|length(A)
+|length(A) * 3
 |COPYING
 |-
 |OP_OVER
-|length(B)
+|length(B) * 3
 |COPYING
 |-
 |OP_PICK
-|length(A) + Length(A-th-from-top)
+|length(A) * 2 + length(A-th-from-top) * 3
 |LENGTHCONV + COPYING
 |-
 |OP_TUCK
-|length(A)
+|length(A) * 3
 |COPYING
 |-
 |OP_ROLL
-|length(A) + 24 * Value of A
-|LENGTHCONV
+|length(A) * 2 + 48 * Value of A
+|LENGTHCONV + ROLL
 |-
 |}
 
 ====Rationale====
 
-These operators copy a stack entry, write to another.  OP_IFDUP has the same worst-case cost as OP_IF + OP_DUP.
+These operators copy a stack entry and write to another.  OP_IFDUP has the same worst-case cost as OP_IF + OP_DUP.
 
-OP_ROLL needs to read its operand, then move that many elements on the stack.  It is the only operand for which the stack manipuilation cost is variable (and, regretfully, non-trivial), so we need to limit it.
+OP_ROLL needs to read its operand, then move that many elements on the stack.  It is the only opcode for which the stack manipulation cost is variable (and, regretfully, non-trivial), so we need to limit it.
 
 A reasonable implementation (and the current bitcoind C++ implementation) is to use 24 bytes for each stack element (a pointer, a size and a maximum capacity), and this value works reasonably in practice.
 
@@ -253,51 +238,51 @@ A reasonable implementation (and the current bitcoind C++ implementation) is to 
 ! Varops Budget Cost
 |-
 |OP_BOOLAND
-|length(A) + length(B)
+|(length(A) + length(B)) * 2
 |COMPARINGZERO
 |-
 |OP_BOOLOR
-|length(A) + length(B)
+|(length(A) + length(B)) * 2
 |COMPARINGZERO
 |-
 |OP_NUMEQUAL
-|MAX(length(A), length(B))
+|MAX(length(A), length(B)) * 2
 |COMPARING + COMPARINGZERO
 |-
 |OP_NUMEQUALVERIFY
-|MAX(length(A), length(B))
+|MAX(length(A), length(B)) * 2
 |COMPARING + COMPARINGZERO
 |-
 |OP_NUMNOTEQUAL
-|MAX(length(A), length(B))
+|MAX(length(A), length(B)) * 2
 |COMPARING + COMPARINGZERO
 |-
 |OP_LESSTHAN
-|MAX(length(A), length(B))
+|MAX(length(A), length(B)) * 2
 |COMPARING + COMPARINGZERO
 |-
 |OP_GREATERTHAN
-|MAX(length(A), length(B))
+|MAX(length(A), length(B)) * 2
 |COMPARING + COMPARINGZERO
 |-
 |OP_LESSTHANOREQUAL
-|MAX(length(A), length(B))
+|MAX(length(A), length(B)) * 2
 |COMPARING + COMPARINGZERO
 |-
 |OP_GREATERTHANOREQUAL
-|MAX(length(A), length(B))
+|MAX(length(A), length(B)) * 2
 |COMPARING + COMPARINGZERO
 |-
 |OP_MIN
-|MAX(length(A), length(B)) * 2
+|MAX(length(A), length(B)) * 4
 |OTHER
 |-
 |OP_MAX
-|MAX(length(A), length(B)) * 2
+|MAX(length(A), length(B)) * 4
 |OTHER
 |-
 |OP_WITHIN
-|MAX(length(C), length(B)) + MAX(length(C), length(A))
+|(MAX(length(C), length(B)) + MAX(length(C), length(A))) * 2
 |COMPARING + COMPARINGZERO
 |}
 
@@ -315,15 +300,15 @@ However, OP_MAX and OP_MIN also normalize their result, which means they can't u
 | Reason
 |-
 |OP_SHA256
-|(Length of the operand) * 10
+|(Length of the operand) * 50
 |HASH
 |-
 |OP_HASH160
-|(Length of the operand) * 10
+|(Length of the operand) * 50
 |HASH
 |-
 |OP_HASH256
-|(Length of the operand) * 10
+|(Length of the operand) * 50
 |HASH
 |}
 


### PR DESCRIPTION
- most relevant changes are to the varops budget, which is now slightly more conservative overall and much more conservative for hashing

- instead of focusing on the 80,000 Schnorr sigs as the benchmark target, I prefer to focus on the quotient (worst case GSR script) / (worst case pre-GSR script), which should be below 1 for all benchmarked machines, the 80,000 Schnorrs are of course contained in the pre-GSR script set

- from the 14 existing benchmarks I evaluated how the cost model could be adapted such that all benchmarks satisfy this ratio

- since hashing cost had to be increased, the rationale for the 5,200 budget factor is gone and we get more granular control over costing by increasing it to 10,000 (also somewhat removing this magic number) while still using integer cost per byte, per default all operations now cost double, which represents a change of -4% budget overall

- hashing now costs 50 instead of 20 (2.5x increase)

- copying now costs 3 instead of 2 (1.5x increase), this was also the motivation for doubling the budget factor, copying should be priced higher than zeroing/comparing due to allocator overhead and cache missing, some benchmarks involving OP_DUP were abnormally slow on some machines with certain operand sizes as we discussed

- also includes new section for benchmark summary linking to the data and some other fixes like typos, grammar and formatting