### PR TITLE
script restoration: restructure opcode tables and address other review comments

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -29,6 +29,7 @@ Atack = "Atack"
 Falke = "Falke"
 Meni = "Meni"
 Ono = "Ono"
+Toom = "Toom"
 
 [files]
 extend-exclude = [

--- a/bip-unknown-script-restoration.mediawiki
+++ b/bip-unknown-script-restoration.mediawiki
@@ -1,0 +1,590 @@
+<pre>
+  BIP: ?
+  Layer: Consensus (soft fork)
+  Title: Restoration of disabled script functionality (Tapscript v2)
+  Authors: Rusty Russell <rusty@rustcorp.com.au>
+           Julian Moik <julianmoik@gmail.com>
+  Status: Draft
+  Type: Specification
+  Assigned: ?
+  License: BSD-3-Clause
+  Discussion: https://groups.google.com/g/bitcoindev/c/GisTcPb8Jco/m/8znWcWwKAQAJ
+  Version: 0.1.0
+</pre>
+
+==Introduction==
+
+===Abstract===
+
+This BIP introduces a new tapleaf version (0xc2) which restores Bitcoin script to its pre-0.3.1 capability, relying on the Varops Budget in [[bip-unknown-varops-budget.mediawiki|BIP-varops]] to prevent the excessive computational time which caused CVE-2010-5137.
+
+In particular, this BIP:
+- Reenables disabled opcodes.
+- Increases the maximum stack object size from 520 bytes to 4,000,000 bytes.
+- Introduces a total stack byte limit of 8,000,000 bytes.
+- Increases the maximum total number of stack objects from 1000 to 32768.
+- Removes the 32-bit size restriction on numerical values.
+- Treats all numerical values as unsigned.
+
+===Copyright===
+
+This document is licensed under the 3-clause BSD license.
+
+===Motivation===
+
+Since Bitcoin v0.3.1 (addressing CVE-2010-5137), Bitcoin's scripting capabilities have been significantly restricted to mitigate known vulnerabilities related to excessive computational time and memory usage.  These early safeguards were necessary to prevent denial-of-service attacks and ensure the stability and reliability of the Bitcoin network.
+
+Unfortunately, these restrictions removed much of the ability for users to control the exact spending conditions of their outputs, which has frustrated the long-held ideal of programmable money without third-party trust.
+
+==Execution of Tapscript v2==
+
+If a taproot leaf has a version of 0xc2, execution of opcodes is as defined below.  All opcodes not explicitly defined here are treated exactly as defined by [[bip-0342.mediawiki|BIP342]].
+
+Validation of a script fails if:
+- It exceeds the remaining varops budget for the transaction.
+- Any stack element exceeds 4,000,000 bytes.
+- The total size of all stack (and altstack) elements exceeds 8,000,000 bytes.
+- The number of stack elements (including altstack elements) exceeds 32768.
+
+===Rationale===
+
+There needs to be some limit on memory usage, to avoid a memory-based denial of service.
+
+Putting the entire transaction on the stack is a foreseeable use case, hence using the block size (4MB) as a limit makes sense.  However, allowing 4MB stack elements is a significant increase in memory requirements, so a total limit of twice that many bytes (8MB) is introduced.  Many stack operations require making at least one copy, so this allows such use.
+
+Putting all outputs or inputs from the transaction on the stack as separate elements requires as much stack capacity as there are inputs or outputs.  The smallest possible input is 34 bytes (allowing almost 26,411 inputs), and the smallest possible output is 9 bytes (allowing almost 111,111 outputs).  However, empty outputs are rare and not economically interesting.  Thus we consider smallest non-OP_RETURN standard output script, which is P2WPKH at 22 bytes, giving a minimum output size of 31 bytes, allowing 32,258 outputs in a maximally-sized transaction.
+
+This makes 32,768 a reasonable upper limit for stack elements.
+
+===SUCCESS Opcodes===
+
+The following opcodes are renamed OP_SUCCESSx, and cause validation to immediately succeed:
+
+* OP_1NEGATE = OP_SUCCESS79
+* OP_NEGATE = OP_SUCCESS143
+* OP_ABS = OP_SUCCESS144<ref>Anthony Towns suggested this could become an opcode which normalized the value on the top of the stack by truncating any trailing zeroes.</ref>
+
+====Rationale====
+
+Negative numbers are not natively supported in v2 Tapscript.  Arbitrary precision makes them difficult to manipulate and negative values are not used meaningfully in bitcoin transactions.
+
+===Non-Arithmetic Opcodes Dealing With Stack Numbers===
+
+The following opcodes are redefined in v2 Tapscript to read numbers from the stack as arbitrary-length little-endian values (instead of CScriptNum):
+
+1. OP_CHECKLOCKTIMEVERIFY
+2. OP_CHECKSEQUENCEVERIFY
+3. OP_VERIFY
+4. OP_PICK
+5. OP_ROLL
+6. OP_IFDUP
+7. OP_CHECKSIGADD
+
+These opcodes are redefined in v2 Tapscript to write numbers to the stack as minimal-length little-endian values (instead of CScriptNum):
+
+1. OP_CHECKSIGADD
+2. OP_DEPTH
+3. OP_SIZE
+
+In addition, the [[bip-0342.mediawiki#specification|BIP-342 success requirement]] is modified to require a non-zero variable-length unsigned integer value (not <code>CastToBool()</code>):
+
+Previously:
+
+    ## If the execution results in anything but exactly one element on the stack which evaluates to true with <code>CastToBool()</code>, fail.
+
+Now:
+
+    ## If the execution results in anything but exactly one element on the stack which contains one or more non-zero bytes, fail.
+
+===Enabled Opcodes===
+
+Fifteen opcodes that were removed in v0.3.1 are re-enabled in v2 Tapscript.
+
+If there are fewer than the required number of stack elements, these opcodes fail validation.  Equivalently, a requirement to pop off the stack which cannot be satisfied causes the opcode to fail validation.
+
+See [[bip-unknown-varops-budget.mediawiki|BIP-varops]] for the meaning of the annotations in the varops cost field.
+
+====Splice Opcodes====
+
+{|
+! Opcode
+! Value
+! Required Stack Elements
+! Varops Cost
+! Varops Reason
+! Definition
+|-
+|OP_CAT
+|126
+|2
+|(length(A) + length(B)) * 3
+|COPYING
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# Append B to A.
+# Push A onto the stack.
+|-
+|OP_SUBSTR
+|127
+|3
+|(length(LEN) + length(BEGIN)) * 2 + MIN(Value of LEN, MAX(length(A) - Value of BEGIN, 0)) * 3
+|LENGTHCONV + COPYING
+|
+# Pop LEN off the stack.
+# Pop BEGIN off the stack.
+# Pop A off the stack.
+# Remove BEGIN bytes from the front of A (all bytes if BEGIN is greater than length of A).
+# If length(A) is greater than value(LEN), truncate A to length value(LEN).
+# Push A onto the stack.
+|-
+|OP_LEFT
+|128
+|2
+|length(OFFSET) * 2
+|LENGTHCONV
+|
+# Pop OFFSET off the stack.
+# Pop A off the stack.
+# If length(A) is greater than value(OFFSET), truncate A to length value(OFFSET).
+# Push A onto the stack.
+|-
+|OP_RIGHT
+|129
+|2
+|length(OFFSET) * 2 + value of OFFSET * 3
+|LENGTHCONV + COPYING
+|
+# Pop OFFSET off the stack.
+# Pop A off the stack.
+# Copy value(OFFSET) bytes from offset length(A) - value(OFFSET) to offset 0, if value(OFFSET) is less than length(A).
+# Push A onto the stack.
+|}
+
+=====Rationale=====
+
+OP_CAT may require a reallocation of A (hence, COPYING A) before appending B.
+
+OP_SUBSTR may have to copy LEN bytes, but also needs to read its two numeric operands.  LEN is limited to the length of the operand minus BEGIN.
+
+OP_LEFT only needs to read its OFFSET operand (truncation is free), whereas OP_RIGHT must copy the bytes, which depends on the OFFSET value.
+
+====Bit Operation Opcodes====
+
+{|
+! Opcode
+! Value
+! Required Stack Elements
+! Varops Cost
+! Varops Reason
+! Definition
+|-
+|OP_INVERT
+|131
+|1
+|length(A) * 4
+|OTHER
+|
+# Pop A off the stack.
+# For each byte in A, replace it with that byte bitwise XOR 0xFF (i.e. invert the bits)
+# Push A onto the stack.
+|-
+|OP_AND
+|132
+|2
+|(length(A) + length(B)) * 2
+|OTHER + ZEROING
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# If B is longer than A, swap B and A.
+# For each byte in A (the longer operand): bitwise AND it with the equivalent byte in B (or 0 if past end of B)
+# Push A onto the stack.
+|-
+|OP_OR
+|133
+|2
+|MIN(length(A), length(B)) * 4
+|OTHER
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# If B is longer than A, swap B and A.
+# For each byte in B (the shorter operand): bitwise OR it with the equivalent byte in A.
+# Push A onto the stack.
+|-
+|OP_XOR
+|134
+|2
+|MIN(length(A), length(B)) * 4
+|OTHER
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# If B is longer than A, swap B and A.
+# For each byte in B (the shorter operand): exclusive OR it with the equivalent byte in A.
+# Push A onto the stack.
+|}
+
+=====Rationale=====
+
+OP_AND, OP_OR and OP_XOR are assumed to fold the results into the longer of the two operands.  This is an OTHER operation (i.e. cost is 2 per byte), but OP_AND needs to do this until one operand is exhausted, and then zero the rest (ZEROING, cost 1 per byte).   OP_OR and OP_XOR can stop as soon as the shorter operand is exhausted.
+
+====Bitshift Opcodes====
+
+Note that these are raw bitshifts, unlike the sign-preserving arithmetic shifts in Bitcoin v0.3.0, and as such they also do not truncate trailing zeroes from results: they are renamed OP_UPSHIFT (nee OP_LSHIFT) and OP_DOWNSHIFT (nee OP_RSHIFT).
+
+{|
+! Opcode
+! Value
+! Required Stack Elements
+! Varops Cost
+! Varops Reason
+! Definition
+|-
+|OP_UPSHIFT
+|152
+|2
+|length(BITS) * 2 + (Value of BITS) / 8 * 2 + length(A) * 3.  If BITS % 8 != 0, add length(A) * 4
+|LENGTHCONV + ZEROING + COPYING. If BITS % 8 != 0, + OTHER.
+|
+# Pop BITS off the stack.
+# Pop A off the stack.
+# If A shifted by value(BITS) would exceed the individual stack limit, fail.
+# If value(BITS) % 8 == 0: simply prepend value(BITS) / 8 zeroes to A.
+# Otherwise: prepend (value(BITS) / 8) + 1 zeroes to A, then shift A *down* (8 - (value(BITS) % 8)) bits.
+# Push A onto the stack.
+|-
+|OP_DOWNSHIFT
+|153
+|2
+|length(BITS) * 2 + MAX((length(A) - (Value of BITS) / 8), 0) * 3
+|LENGTHCONV + COPYING
+|
+# Pop BITS off the stack.
+# Pop A off the stack.
+# For BITOFF from 0 to (length(A)-1) * 8 - value(BITS):
+    # Copy each bit in A from BITOFF + value(BITS) to BITOFF.
+# Truncate A to remove value(BITS) / 8 bytes from the end (or all bytes, if value(BITS) / 8 > length(A)).
+# Push A onto the stack.
+|}
+
+=====Rationale=====
+
+DOWNSHIFT needs to read the value of the second operand BITS.  It then needs to move the remainder of A (the part after offset BITS/8 bytes).  In practice this should be implemented in word-size chunks, not bit-by-bit!
+
+UPSHIFT also needs to read BITS.  In general, it may need to reallocate (copying A and zeroing out remaining words).  If not moving an exact number of bytes (BITS % 8 != 0), another pass is needed to perform the bitshift.
+
+OP_UPSHIFT can produce huge results, and so must be checked for limits prior to evaluation.  It is also carefully defined to avoid reallocating twice (reallocating to prepend bytes, then again to append a single byte) which has the practical advantage of being able to share the same downward bitshift routine as OP_DOWNSHIFT.
+
+====Multiply and Divide Opcodes====
+
+{|
+! Opcode
+! Value
+! Required Stack Elements
+! Varops Cost
+! Varops Reason
+! Definition
+|-
+|OP_2MUL
+|141
+|1
+|length(A) * 7
+|OTHER + COPYING
+|
+# Pop A off the stack.
+# Shift each byte in A 1 bit to the left (increasing values, equivalent to C's << operator), tracking the last non-zero value.
+# If the final byte overflows, append a single 1 byte.
+# Otherwise, truncate A at the last non-zero byte.
+# Push A onto the stack.
+|-
+|OP_2DIV
+|142
+|1
+|length(A) * 4
+|OTHER
+|
+# Pop A off the stack.
+# Shift each byte 1 bit to the right (decreasing values, equivalent to C's >> operator), tracking the last non-zero value.
+# Truncate A at the last non-zero byte.
+# Push A onto the stack.
+|-
+|OP_MUL
+|149
+|2
+|(length(A) + length(B)) * 3 + (length(A) + 7) / 8 * length(B) * 27  (BEWARE OVERFLOW)
+|See Appendix
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
+# Allocate an all-zero vector R of length equal to length(A) + length(B).
+# For each word in A, multiply it by B and add it into the vector R, offset by the word offset in A.
+# Truncate R at the last non-zero byte.
+# Push R onto the stack.
+|-
+|OP_DIV
+|150
+|2
+|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW)
+|See Appendix
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
+# If B is empty or all zeroes, fail.
+# Perform division as per Knuth's The Art of Computer Programming v2 page 272, Algorithm D "Division of non-negative integers".
+# Trim trailing zeroes off the quotient.
+# Push the quotient onto the stack.
+|-
+|OP_MOD
+|151
+|2
+|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW)
+|See Appendix
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
+# If B is empty or all zeroes, fail.
+# Perform division as per Knuth's The Art of Computer Programming v2 page 272, Algorithm D "Division of non-negative integers".
+# Trim trailing zeroes off the remainder.
+# Push the remainder onto the stack.
+|}
+
+=====Rationale=====
+
+These opcodes can be computationally intensive, which is why the varops budget must be checked before operations.  OP_2MUL and OP_2DIV are far simpler, equivalent to OP_UPSHIFT and OP_DOWNSHIFT by 1 bit, except truncating the most-significant zero bytes.
+
+The detailed rationale for these costs can be found in Appendix A.
+
+===Limited Hashing Opcodes===
+
+OP_RIPEMD160 and OP_SHA1 are now defined to FAIL validation if their operands exceed 520 bytes.<ref>There seems little reason to allow large hashing with SHA1 and RIPEMD, and they are not as optimized as SHA256, so we restrict their usage to the older byte limit.</ref>
+
+===Extended Opcodes===
+
+The opcodes OP_ADD, OP_SUB, OP_1ADD and OP_1SUB are redefined in v2 Tapscript to operate on variable-length unsigned integers.  These always produce minimal values (no trailing zero bytes).
+
+{|
+! Opcode
+! Value
+! Required Stack Elements
+! Varops Cost
+! Varops Reason
+! Definition
+|-
+|OP_ADD
+|147
+|2
+|MAX(length(A), length(B)) * 9
+|ARITH + COPYING
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# Option 1: trim trailing zeroes off A and B.
+# If B is longer than A, swap A and B.
+# For each byte in B, add it and previous overflow into the equivalent byte in A, remembering next overflow.
+# If there was final overflow, append a 1 byte to A.
+# Option 2: If there was no final overflow, remember last non-zero byte written into A, and truncate A after that point.
+# Either Option 1 or Option 2 MUST be implemented.
+|-
+|OP_1ADD
+|139
+|1
+|MAX(1, length(A)) * 9
+|ARITH + COPYING
+|
+# Pop A off the stack.
+# Let B = 1, and continue as OP_ADD.
+|-
+|OP_SUB
+|148
+|2
+|MAX(length(A), length(B)) * 6
+|ARITH
+|
+# Pop B off the stack.
+# Pop A off the stack.
+# For each byte in B, subtract it and previous underflow from the equivalent byte in A, remembering next underflow.
+# If there was final underflow, fail validation.
+# Remember last non-zero byte written into A, and truncate A after that point.
+|-
+|OP_1SUB
+|140
+|1
+|MAX(1, length(A)) * 6
+|ARITH
+|
+# Pop A off the stack.
+# Let B = 1, and continue as OP_SUB.
+|}
+
+====Rationale====
+
+Note that the basic cost for ADD is six times the maximum operand length (ARITH), but then considers the case where a reallocation and copy needs to occur to append the final carry byte (COPYING, which costs 3 units per byte).
+
+Subtraction is cheaper because underflow does not occur: that is a validation failure, as mathematicians agree the result would not be natural.
+
+===Misc Operators===
+
+The following opcodes have costs below:
+
+{|
+! Opcode
+! Varops Budget Cost
+! Varops Reason
+|-
+| OP_CHECKLOCKTIMEVERIFY
+| Length of operand * 2
+| LENGTHCONV
+|-
+| OP_CHECKSEQUENCEVERIFY
+| Length of operand * 2
+| LENGTHCONV
+|-
+| OP_CHECKSIGADD
+| MAX(1, length(number operand)) * 9 + 500,000
+| ARITH + COPYING + SIGCHECK
+|-
+| OP_CHECKSIG
+| 500,000
+| SIGCHECK
+|-
+| OP_CHECKSIGVERIFY
+| 500,000
+| SIGCHECK
+|}
+
+====Rationale====
+
+OP_CHECKSIGADD does an OP_1ADD on success, so we use the same cost as that.  For simplicity, this is charged whether the OP_CHECKSIGADD succeeds or not.
+
+===Other Operators===
+
+The varops costs of the following opcodes are defined in [[bip-unknown-varops-budget.mediawiki|BIP-varops]]:
+
+* OP_VERIFY
+* OP_NOT
+* OP_0NOTEQUAL
+* OP_EQUAL
+* OP_EQUALVERIFY
+* OP_2DUP
+* OP_3DUP
+* OP_2OVER
+* OP_IFDUP
+* OP_DUP
+* OP_OVER
+* OP_PICK
+* OP_TUCK
+* OP_ROLL
+* OP_BOOLOR
+* OP_NUMEQUAL
+* OP_NUMEQUALVERIFY
+* OP_NUMNOTEQUAL
+* OP_LESSTHAN
+* OP_GREATERTHAN
+* OP_LESSTHANOREQUAL
+* OP_GREATERTHANOREQUAL
+* OP_MIN
+* OP_MAX
+* OP_WITHIN
+* OP_SHA256
+* OP_HASH160
+* OP_HASH256
+
+Those with costs not defined here have a cost of 0 (they do not operate on variable-length stack objects).
+
+===Normalization of Results===
+
+Note that only arithmetic operations (those which treat operands as numbers) normalize their results: bit operations do not.  Thus operations such as "0 OP_ADD" and "2 OP_MUL" will never result in a top stack entry with a trailing zero byte, but "0 OP_OR" and "1 OP_UPSHIFT" may.
+
+To be clear, the following operations are arithmetic and will normalize their results:
+
+* OP_1ADD
+* OP_1SUB
+* OP_2MUL
+* OP_2DIV
+* OP_ADD
+* OP_SUB
+* OP_MUL
+* OP_DIV
+* OP_MOD
+* OP_MIN
+* OP_MAX
+
+==Backwards compatibility==
+
+This BIP defines a previously unused (and thus, always-successful) tapscript version, for backwards compatibility.
+
+==Reference Implementation==
+
+Work in progress:
+
+	https://github.com/jmoik/bitcoin/tree/gsr
+
+==Thanks==
+
+This BIP would not exist without the thoughtful contributions of coders who considered all the facets carefully and thoroughly, and also my inspirational wife Alex and my kids who have been tirelessly supportive of my esoteric-seeming endeavors such as this!
+
+In alphabetical order:
+- Anthony Towns
+- Brandon Black (aka Reardencode)
+- John Light
+- Jonas Nick
+- Rijndael (aka rot13maxi)
+- Steven Roose
+- FIXME: your name here!
+
+==Appendix A: Cost Model Calculations for Multiply and Divide==
+
+Multiplication and division require multiple passes over the operands, meaning a cost proportional to the square of the lengths involved, and the word size used for that iteration makes a difference.  We assume 8 bytes (64 bits) at a time are evaluated, and the ability to multiply two 64-bit numbers and receive a 128-bit result, and divide a 128-bit number by a 64 bit number to receive a 128 bit quotient and remainder.  This is true on modern 64-bit CPUs (sometimes using multiple instructions).
+
+===Multiplication Cost===
+
+For multiplication, the steps break down like so:
+1. Allocate and zero the result: cost = (length(A) + length(B)) * 2 (ZEROING)
+2. For each word in A:
+  * Multiply by each word in B, into a scratch vector: cost = 6 * length(B) (ARITH)
+  * Sum scratch vector at the word offset into the result: cost = 6 * length(B) (ARITH)
+
+Note: we do not assume Karatsuba, Toom-Cook or other optimizations.
+
+The theoretical cost is: (length(A) + length(B)) * 2 + (length(A) + 7) / 8 * length(B) * 12.
+
+However, benchmarking reveals that the inner loop overhead (branch misprediction, cache effects on small elements) is undercosted by the theoretical model.  A 2.25× multiplier on the quadratic term accounts for this, giving a cost of: (length(A) + length(B)) * 3 + (length(A) + 7) / 8 * length(B) * 27.
+
+This is slightly asymmetric: in practice an implementation usually finds that CPU pipelining means choosing B as the larger operand is optimal.
+
+===Division Cost====
+
+For division, the steps break down like so:
+
+1. Bit shift both operands to set top bit of B (OP_UPSHIFT, without overflow for B): cost = length(A) * 6 + length(B) * 4
+
+2. Trim trailing bytes.  This costs according to the number of byte removed, but since that is subtractive on future costs, we ignore it.
+
+3. If B is longer, the answer is 0 already.  So assume A is longer from now on (or equal length).
+
+4. Compare: cost = length(A) * 2 (COMPARING)
+
+5. Subtract: cost = length(A) * 6 (ARITH)
+
+6. for (length(A) - NormalizedLength(B)) in words:
+   1. Multiply word by B -> scratch: cost = NormalizedLength(B) * 6 (ARITH)
+   2. Subtract scratch from A: cost = length(A) * 6 (ARITH)
+   3. Add B into A (no overflow): cost = length(A) * 6 (ARITH)
+   4. Shrink A by 1 word.
+
+7. OP_MOD: shift A down, trim trailing zeroes: cost = length(A) * 4
+
+8. OP_DIV: trim trailing zeros: cost = length(A) * 4
+
+Note that the loop at step 6 shrinks A every time, so the *average* cost of each iteration is (NormalizedLength(B) * 6 + length(A) * 12) / 2.  The cost of step 6 is:
+
+	(length(A) - NormalizedLength(B)) / 8 * (NormalizedLength(B) * 6 + length(A) * 12) / 2
+
+The worst case is when NormalizedLength(B) is 0: length(A) * length(A) * 2 / 3.
+
+The cost for all the steps is: length(A) * 18 + length(B) * 4 + length(A) * length(A) * 2 / 3.

--- a/bip-unknown-script-restoration.mediawiki
+++ b/bip-unknown-script-restoration.mediawiki
@@ -22,7 +22,7 @@ In particular, this BIP:
 - Reenables disabled opcodes.
 - Increases the maximum stack object size from 520 bytes to 4,000,000 bytes.
 - Introduces a total stack byte limit of 8,000,000 bytes.
-- Increases the maximum total number of stack objects from 1000 to 32768.
+- Increases the maximum total number of stack objects from 1,000 to 32,768.
 - Removes the 32-bit size restriction on numerical values.
 - Treats all numerical values as unsigned.
 
@@ -44,7 +44,7 @@ Validation of a script fails if:
 - It exceeds the remaining varops budget for the transaction.
 - Any stack element exceeds 4,000,000 bytes.
 - The total size of all stack (and altstack) elements exceeds 8,000,000 bytes.
-- The number of stack elements (including altstack elements) exceeds 32768.
+- The number of stack elements (including altstack elements) exceeds 32,768.
 
 ===Rationale===
 
@@ -72,19 +72,19 @@ Negative numbers are not natively supported in v2 Tapscript.  Arbitrary precisio
 
 The following opcodes are redefined in v2 Tapscript to read numbers from the stack as arbitrary-length little-endian values (instead of CScriptNum):
 
-1. OP_CHECKLOCKTIMEVERIFY
-2. OP_CHECKSEQUENCEVERIFY
-3. OP_VERIFY
-4. OP_PICK
-5. OP_ROLL
-6. OP_IFDUP
-7. OP_CHECKSIGADD
+# OP_CHECKLOCKTIMEVERIFY
+# OP_CHECKSEQUENCEVERIFY
+# OP_VERIFY
+# OP_PICK
+# OP_ROLL
+# OP_IFDUP
+# OP_CHECKSIGADD
 
 These opcodes are redefined in v2 Tapscript to write numbers to the stack as minimal-length little-endian values (instead of CScriptNum):
 
-1. OP_CHECKSIGADD
-2. OP_DEPTH
-3. OP_SIZE
+# OP_CHECKSIGADD
+# OP_DEPTH
+# OP_SIZE
 
 In addition, the [[bip-0342.mediawiki#specification|BIP-342 success requirement]] is modified to require a non-zero variable-length unsigned integer value (not <code>CastToBool()</code>):
 
@@ -102,63 +102,47 @@ Fifteen opcodes that were removed in v0.3.1 are re-enabled in v2 Tapscript.
 
 If there are fewer than the required number of stack elements, these opcodes fail validation.  Equivalently, a requirement to pop off the stack which cannot be satisfied causes the opcode to fail validation.
 
-See [[bip-unknown-varops-budget.mediawiki|BIP-varops]] for the meaning of the annotations in the varops cost field.
+Stack values are byte arrays representing little-endian unsigned integers: byte 0 is the least significant, and the last byte is the most significant.  A value in ''minimal'' form has no trailing zero bytes (i.e., the most significant byte is non-zero).  To ''normalize'' a value is to convert it to minimal form by removing trailing zero bytes.
+
+See [[bip-unknown-varops-budget.mediawiki|BIP-varops]] for the meaning of the annotations (in parentheses) in the varops cost field.
 
 ====Splice Opcodes====
 
 {|
 ! Opcode
 ! Value
-! Required Stack Elements
+! Input
+! Output
 ! Varops Cost
-! Varops Reason
 ! Definition
 |-
 |OP_CAT
 |126
-|2
-|(length(A) + length(B)) * 3
-|COPYING
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# Append B to A.
-# Push A onto the stack.
+|[A, B]
+|[A ‖ B]
+|(length(A) + length(B)) * 3(COPYING)
+|Concatenates A and B.
 |-
 |OP_SUBSTR
 |127
-|3
-|(length(LEN) + length(BEGIN)) * 2 + MIN(Value of LEN, MAX(length(A) - Value of BEGIN, 0)) * 3
-|LENGTHCONV + COPYING
-|
-# Pop LEN off the stack.
-# Pop BEGIN off the stack.
-# Pop A off the stack.
-# Remove BEGIN bytes from the front of A (all bytes if BEGIN is greater than length of A).
-# If length(A) is greater than value(LEN), truncate A to length value(LEN).
-# Push A onto the stack.
+|[A, BEGIN, LEN]
+|[substr(A, BEGIN, LEN)]
+|(length(LEN) + length(BEGIN)) * 2(LENGTHCONV) + MIN(Value of LEN, MAX(length(A) - Value of BEGIN, 0)) * 3(COPYING)
+|Returns up to LEN bytes of A starting at byte offset BEGIN. Returns empty if BEGIN exceeds length of A.
 |-
 |OP_LEFT
 |128
-|2
-|length(OFFSET) * 2
-|LENGTHCONV
-|
-# Pop OFFSET off the stack.
-# Pop A off the stack.
-# If length(A) is greater than value(OFFSET), truncate A to length value(OFFSET).
-# Push A onto the stack.
+|[A, OFFSET]
+|[left(A, OFFSET)]
+|length(OFFSET) * 2(LENGTHCONV)
+|Returns the first OFFSET bytes of A, or all of A if shorter.
 |-
 |OP_RIGHT
 |129
-|2
-|length(OFFSET) * 2 + value of OFFSET * 3
-|LENGTHCONV + COPYING
-|
-# Pop OFFSET off the stack.
-# Pop A off the stack.
-# Copy value(OFFSET) bytes from offset length(A) - value(OFFSET) to offset 0, if value(OFFSET) is less than length(A).
-# Push A onto the stack.
+|[A, OFFSET]
+|[right(A, OFFSET)]
+|length(OFFSET) * 2(LENGTHCONV) + value of OFFSET * 3(COPYING)
+|Returns the last OFFSET bytes of A, or all of A if shorter.
 |}
 
 =====Rationale=====
@@ -171,102 +155,76 @@ OP_LEFT only needs to read its OFFSET operand (truncation is free), whereas OP_R
 
 ====Bit Operation Opcodes====
 
+These opcodes perform bitwise operations on their operands, which are little-endian encoded unsigned integers.  When operands differ in length, byte positions are aligned from byte 0 (the least significant byte), and the shorter operand is implicitly zero-extended at the most significant end.  This is equivalent to applying the mathematical bitwise operation to the unsigned integer values the operands represent.
+
 {|
 ! Opcode
 ! Value
-! Required Stack Elements
+! Input
+! Output
 ! Varops Cost
-! Varops Reason
 ! Definition
 |-
 |OP_INVERT
 |131
-|1
-|length(A) * 4
-|OTHER
-|
-# Pop A off the stack.
-# For each byte in A, replace it with that byte bitwise XOR 0xFF (i.e. invert the bits)
-# Push A onto the stack.
+|[A]
+|[~A]
+|length(A) * 4(OTHER)
+|Bitwise inversion of all bits in A.
 |-
 |OP_AND
 |132
-|2
-|(length(A) + length(B)) * 2
-|OTHER + ZEROING
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# If B is longer than A, swap B and A.
-# For each byte in A (the longer operand): bitwise AND it with the equivalent byte in B (or 0 if past end of B)
-# Push A onto the stack.
+|[A, B]
+|[A ∧ B]
+|(length(A) + length(B)) * 2(OTHER + ZEROING)
+|Bitwise AND of A and B.
 |-
 |OP_OR
 |133
-|2
-|MIN(length(A), length(B)) * 4
-|OTHER
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# If B is longer than A, swap B and A.
-# For each byte in B (the shorter operand): bitwise OR it with the equivalent byte in A.
-# Push A onto the stack.
+|[A, B]
+|[A ∨ B]
+|MIN(length(A), length(B)) * 4(OTHER)
+|Bitwise OR of A and B.
 |-
 |OP_XOR
 |134
-|2
-|MIN(length(A), length(B)) * 4
-|OTHER
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# If B is longer than A, swap B and A.
-# For each byte in B (the shorter operand): exclusive OR it with the equivalent byte in A.
-# Push A onto the stack.
+|[A, B]
+|[A ⊕ B]
+|MIN(length(A), length(B)) * 4(OTHER)
+|Bitwise XOR of A and B.
 |}
 
 =====Rationale=====
 
-OP_AND, OP_OR and OP_XOR are assumed to fold the results into the longer of the two operands.  This is an OTHER operation (i.e. cost is 2 per byte), but OP_AND needs to do this until one operand is exhausted, and then zero the rest (ZEROING, cost 1 per byte).   OP_OR and OP_XOR can stop as soon as the shorter operand is exhausted.
+When operands differ in length, the shorter operand is zero-extended at the most significant end (the back, in little-endian encoding).  For OP_AND this means high bytes beyond the shorter operand become zero, exactly as expected when AND-ing with a numerically narrower value.  For OP_OR and OP_XOR, those high bytes are unchanged since OR/XOR with zero is the identity.
+
+OP_AND, OP_OR and OP_XOR are assumed to fold the results into the longer of the two operands.  This is an OTHER operation (i.e. cost is 2 per byte), but OP_AND needs to do this until one operand is exhausted, and then zero the rest (ZEROING, cost 1 per byte).   OP_OR and OP_XOR can stop as soon as the shorter operand is exhausted, since the remaining bytes of the longer operand are unchanged by OR/XOR with zero.
 
 ====Bitshift Opcodes====
 
-Note that these are raw bitshifts, unlike the sign-preserving arithmetic shifts in Bitcoin v0.3.0, and as such they also do not truncate trailing zeroes from results: they are renamed OP_UPSHIFT (nee OP_LSHIFT) and OP_DOWNSHIFT (nee OP_RSHIFT).
+Note that these are raw bitshifts, unlike the sign-preserving arithmetic shifts in Bitcoin v0.3.0, and as such they do not produce results in minimal form: they are renamed OP_UPSHIFT (formerly OP_LSHIFT) and OP_DOWNSHIFT (formerly OP_RSHIFT).
 
 {|
 ! Opcode
 ! Value
-! Required Stack Elements
+! Input
+! Output
 ! Varops Cost
-! Varops Reason
 ! Definition
 |-
 |OP_UPSHIFT
 |152
-|2
-|length(BITS) * 2 + (Value of BITS) / 8 * 2 + length(A) * 3.  If BITS % 8 != 0, add length(A) * 4
-|LENGTHCONV + ZEROING + COPYING. If BITS % 8 != 0, + OTHER.
-|
-# Pop BITS off the stack.
-# Pop A off the stack.
-# If A shifted by value(BITS) would exceed the individual stack limit, fail.
-# If value(BITS) % 8 == 0: simply prepend value(BITS) / 8 zeroes to A.
-# Otherwise: prepend (value(BITS) / 8) + 1 zeroes to A, then shift A *down* (8 - (value(BITS) % 8)) bits.
-# Push A onto the stack.
+|[A, BITS]
+|[A << BITS]
+|length(BITS) * 2(LENGTHCONV) + (Value of BITS) / 8 * 2(ZEROING) + length(A) * 3(COPYING).  If BITS % 8 != 0, add length(A) * 4(OTHER)
+|Shifts A left by BITS bits. Fails if the result would exceed the stack element size limit.
 |-
 |OP_DOWNSHIFT
 |153
-|2
-|length(BITS) * 2 + MAX((length(A) - (Value of BITS) / 8), 0) * 3
-|LENGTHCONV + COPYING
-|
-# Pop BITS off the stack.
-# Pop A off the stack.
-# For BITOFF from 0 to (length(A)-1) * 8 - value(BITS):
-    # Copy each bit in A from BITOFF + value(BITS) to BITOFF.
-# Truncate A to remove value(BITS) / 8 bytes from the end (or all bytes, if value(BITS) / 8 > length(A)).
-# Push A onto the stack.
+|[A, BITS]
+|[A >> BITS]
+|length(BITS) * 2(LENGTHCONV) + MAX((length(A) - (Value of BITS) / 8), 0) * 3(COPYING)
+|Shifts A right by BITS bits, discarding bits shifted out.
 |}
 
 =====Rationale=====
@@ -282,80 +240,50 @@ OP_UPSHIFT can produce huge results, and so must be checked for limits prior to 
 {|
 ! Opcode
 ! Value
-! Required Stack Elements
+! Input
+! Output
 ! Varops Cost
-! Varops Reason
 ! Definition
 |-
 |OP_2MUL
 |141
-|1
-|length(A) * 7
-|OTHER + COPYING
-|
-# Pop A off the stack.
-# Shift each byte in A 1 bit to the left (increasing values, equivalent to C's << operator), tracking the last non-zero value.
-# If the final byte overflows, append a single 1 byte.
-# Otherwise, truncate A at the last non-zero byte.
-# Push A onto the stack.
+|[A]
+|[A × 2]
+|length(A) * 7(OTHER + COPYING)
+|Multiplies A by 2. Result is normalized.
 |-
 |OP_2DIV
 |142
-|1
-|length(A) * 4
-|OTHER
-|
-# Pop A off the stack.
-# Shift each byte 1 bit to the right (decreasing values, equivalent to C's >> operator), tracking the last non-zero value.
-# Truncate A at the last non-zero byte.
-# Push A onto the stack.
+|[A]
+|[A ÷ 2]
+|length(A) * 4(OTHER)
+|Divides A by 2, discarding the remainder. Result is normalized.
 |-
 |OP_MUL
 |149
-|2
-|(length(A) + length(B)) * 3 + (length(A) + 7) / 8 * length(B) * 27  (BEWARE OVERFLOW)
-|See Appendix
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
-# Allocate an all-zero vector R of length equal to length(A) + length(B).
-# For each word in A, multiply it by B and add it into the vector R, offset by the word offset in A.
-# Truncate R at the last non-zero byte.
-# Push R onto the stack.
+|[A, B]
+|[A × B]
+|(length(A) + length(B)) * 3 + (length(A) + 7) / 8 * length(B) * 27  (BEWARE OVERFLOW, See Appendix)
+|Multiplies A by B. Varops cost is checked before evaluation. Result is normalized.
 |-
 |OP_DIV
 |150
-|2
-|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW)
-|See Appendix
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
-# If B is empty or all zeroes, fail.
-# Perform division as per Knuth's The Art of Computer Programming v2 page 272, Algorithm D "Division of non-negative integers".
-# Trim trailing zeroes off the quotient.
-# Push the quotient onto the stack.
+|[A, B]
+|[A ÷ B]
+|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW, See Appendix)
+|Integer division of A by B, returning the quotient. Fails if B is zero. Varops cost is checked before evaluation. Result is normalized.
 |-
 |OP_MOD
 |151
-|2
-|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW)
-|See Appendix
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# Calculate the varops cost of the operation: if it exceeds the remaining budget, fail.
-# If B is empty or all zeroes, fail.
-# Perform division as per Knuth's The Art of Computer Programming v2 page 272, Algorithm D "Division of non-negative integers".
-# Trim trailing zeroes off the remainder.
-# Push the remainder onto the stack.
+|[A, B]
+|[A mod B]
+|length(A) * 18 + length(B) * 4 + length(A)^2 * 2 / 3  (BEWARE OVERFLOW, See Appendix)
+|Integer division of A by B, returning the remainder. Fails if B is zero. Varops cost is checked before evaluation. Result is normalized.
 |}
 
 =====Rationale=====
 
-These opcodes can be computationally intensive, which is why the varops budget must be checked before operations.  OP_2MUL and OP_2DIV are far simpler, equivalent to OP_UPSHIFT and OP_DOWNSHIFT by 1 bit, except truncating the most-significant zero bytes.
+These opcodes can be computationally intensive, which is why the varops budget must be checked before operations.  OP_2MUL and OP_2DIV are far simpler, equivalent to OP_UPSHIFT and OP_DOWNSHIFT by 1 bit, except they normalize the result.
 
 The detailed rationale for these costs can be found in Appendix A.
 
@@ -365,60 +293,43 @@ OP_RIPEMD160 and OP_SHA1 are now defined to FAIL validation if their operands ex
 
 ===Extended Opcodes===
 
-The opcodes OP_ADD, OP_SUB, OP_1ADD and OP_1SUB are redefined in v2 Tapscript to operate on variable-length unsigned integers.  These always produce minimal values (no trailing zero bytes).
+The opcodes OP_ADD, OP_SUB, OP_1ADD and OP_1SUB are redefined in v2 Tapscript to operate on variable-length unsigned integers.  These always produce values in minimal form.
 
 {|
 ! Opcode
 ! Value
-! Required Stack Elements
+! Input
+! Output
 ! Varops Cost
-! Varops Reason
 ! Definition
 |-
 |OP_ADD
 |147
-|2
-|MAX(length(A), length(B)) * 9
-|ARITH + COPYING
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# Option 1: trim trailing zeroes off A and B.
-# If B is longer than A, swap A and B.
-# For each byte in B, add it and previous overflow into the equivalent byte in A, remembering next overflow.
-# If there was final overflow, append a 1 byte to A.
-# Option 2: If there was no final overflow, remember last non-zero byte written into A, and truncate A after that point.
-# Either Option 1 or Option 2 MUST be implemented.
+|[A, B]
+|[A + B]
+|MAX(length(A), length(B)) * 9(ARITH + COPYING)
+|Adds A and B. Result is normalized.
 |-
 |OP_1ADD
 |139
-|1
-|MAX(1, length(A)) * 9
-|ARITH + COPYING
-|
-# Pop A off the stack.
-# Let B = 1, and continue as OP_ADD.
+|[A]
+|[A + 1]
+|MAX(1, length(A)) * 9(ARITH + COPYING)
+|Adds 1 to A. Equivalent to OP_ADD with B = 1.
 |-
 |OP_SUB
 |148
-|2
-|MAX(length(A), length(B)) * 6
-|ARITH
-|
-# Pop B off the stack.
-# Pop A off the stack.
-# For each byte in B, subtract it and previous underflow from the equivalent byte in A, remembering next underflow.
-# If there was final underflow, fail validation.
-# Remember last non-zero byte written into A, and truncate A after that point.
+|[A, B]
+|[A − B]
+|MAX(length(A), length(B)) * 6(ARITH)
+|Subtracts B from A. Fails if B > A (underflow). Result is normalized.
 |-
 |OP_1SUB
 |140
-|1
-|MAX(1, length(A)) * 6
-|ARITH
-|
-# Pop A off the stack.
-# Let B = 1, and continue as OP_SUB.
+|[A]
+|[A − 1]
+|MAX(1, length(A)) * 6(ARITH)
+|Subtracts 1 from A. Equivalent to OP_SUB with B = 1.
 |}
 
 ====Rationale====
@@ -434,27 +345,21 @@ The following opcodes have costs below:
 {|
 ! Opcode
 ! Varops Budget Cost
-! Varops Reason
 |-
 | OP_CHECKLOCKTIMEVERIFY
-| Length of operand * 2
-| LENGTHCONV
+| Length of operand * 2(LENGTHCONV)
 |-
 | OP_CHECKSEQUENCEVERIFY
-| Length of operand * 2
-| LENGTHCONV
+| Length of operand * 2(LENGTHCONV)
 |-
 | OP_CHECKSIGADD
-| MAX(1, length(number operand)) * 9 + 500,000
-| ARITH + COPYING + SIGCHECK
+| MAX(1, length(number operand)) * 9(ARITH + COPYING) + 500,000(SIGCHECK)
 |-
 | OP_CHECKSIG
-| 500,000
-| SIGCHECK
+| 500,000(SIGCHECK)
 |-
 | OP_CHECKSIGVERIFY
-| 500,000
-| SIGCHECK
+| 500,000(SIGCHECK)
 |}
 
 ====Rationale====
@@ -498,7 +403,7 @@ Those with costs not defined here have a cost of 0 (they do not operate on varia
 
 ===Normalization of Results===
 
-Note that only arithmetic operations (those which treat operands as numbers) normalize their results: bit operations do not.  Thus operations such as "0 OP_ADD" and "2 OP_MUL" will never result in a top stack entry with a trailing zero byte, but "0 OP_OR" and "1 OP_UPSHIFT" may.
+Note that only arithmetic operations (those which treat operands as numbers) produce results in minimal form: bit operations do not.  Thus operations such as "0 OP_ADD" and "2 OP_MUL" will always produce a minimal result, but "0 OP_OR" and "1 OP_UPSHIFT" may not.
 
 To be clear, the following operations are arithmetic and will normalize their results:
 
@@ -557,7 +462,7 @@ However, benchmarking reveals that the inner loop overhead (branch misprediction
 
 This is slightly asymmetric: in practice an implementation usually finds that CPU pipelining means choosing B as the larger operand is optimal.
 
-===Division Cost====
+===Division Cost===
 
 For division, the steps break down like so:
 
@@ -577,9 +482,9 @@ For division, the steps break down like so:
    3. Add B into A (no overflow): cost = length(A) * 6 (ARITH)
    4. Shrink A by 1 word.
 
-7. OP_MOD: shift A down, trim trailing zeroes: cost = length(A) * 4
+7. OP_MOD: shift A down, normalize: cost = length(A) * 4
 
-8. OP_DIV: trim trailing zeros: cost = length(A) * 4
+8. OP_DIV: normalize: cost = length(A) * 4
 
 Note that the loop at step 6 shrinks A every time, so the *average* cost of each iteration is (NormalizedLength(B) * 6 + length(A) * 12) / 2.  The cost of step 6 is:
 

--- a/bip-unknown-varops-budget.mediawiki
+++ b/bip-unknown-varops-budget.mediawiki
@@ -1,0 +1,349 @@
+<pre>
+  BIP: ?
+  Layer: Consensus (soft fork)
+  Title: Varops Budget For Script Runtime Constraint
+  Authors: Rusty Russell <rusty@rustcorp.com.au>
+           Julian Moik <julianmoik@gmail.com>
+  Status: Draft
+  Type: Specification
+  Assigned: ?
+  License: BSD-3-Clause
+  Discussion: https://groups.google.com/g/bitcoindev/c/GisTcPb8Jco/m/8znWcWwKAQAJ
+              https://delvingbitcoin.org/t/benchmarking-bitcoin-script-evaluation-for-the-varops-budget-great-script-restoration/2094
+  Version: 0.2.0
+</pre>
+
+==Introduction==
+
+===Abstract===
+
+This BIP defines a "varops budget", which generalizes the "sigops budget" introduced in [[bip-0342.mediawiki|BIP342]] to non-signature operations.
+
+This BIP is a useful framework for other BIPs to draw upon, and provides opcode examples which are always less restrictive than current rules.
+
+===Copyright===
+
+This document is licensed under the 3-clause BSD license.
+
+===Motivation===
+
+Since Bitcoin v0.3.1 (addressing CVE-2010-5137), Bitcoin's scripting capabilities have been significantly restricted to mitigate known vulnerabilities related to excessive computational time and memory usage.  These early safeguards were necessary to prevent denial-of-service attacks and ensure the stability and reliability of the Bitcoin network.
+
+However, as Bitcoin usage becomes more sophisticated, these limitations are becoming more salient.  New proposals often must explicitly address potential performance pitfalls by severely limiting their scope, introducing specialized caching strategies to mitigate execution costs, or using the existing sigops budget in ad-hoc ways to enforce dynamic execution limits.
+
+This BIP introduces a simple, systematic and explicit cost framework for evaluating script operations based on stack data interactions, using worst-case behavior as the limiting factor.  Even with these pessimistic assumptions, large classes of scripts can be shown to be within budget (for all possible inputs) by static analysis.
+
+===A Model For Opcodes Dealing With Stack Data===
+
+Without an explicit and low limit on the size of stack operands, the bottleneck for script operations is based on the time taken to process the stack data it accesses (with the exception of signature operations).  The cost model uses the length of the stack inputs (or occasionally, outputs), hence the term "varops".
+
+- We assume that the manipulation of the stack vector itself (e.g. OP_DROP) is negligible (with the exception of OP_ROLL)
+- We assume that memory allocation and deallocation overhead is negligible.
+- We do not consider the cost of the script interpretation itself, which is necessarily limited by block size.
+- We assume implementations use simple linear arrays/vectors of contiguous memory.
+- We assume implementations use linear accesses to stack data (perhaps multiple times): random accesses would require an extension to the model.
+- We assume object size is limited to the entire transaction (4,000,000 bytes, worst-case).
+- Costs are based on the worst-case behavior of each opcode.
+
+The last two assumptions make a large difference in practice: normal usage on small, cache-hot objects is much faster than this model suggests.  But an implementation which is more efficient than the versions modeled does not introduce any problems (though a future soft-fork version may want to reflect this in reduced costings): only an implementation with a significantly worse worst-case behavior would be problematic.
+
+==Design==
+
+A per-transaction integer "varops budget" is determined by multiplying the total transaction weight by the fixed factor 10,000 (chosen to make operation costs all integer values). The budget is transaction-wide (rather than per-input) to allow for cross-input introspection: a small input may reasonably access larger inputs.
+
+Opcodes consume budget as they are executed, based on the length (not generally the value) of their parameters as detailed below.  A transaction which exceeds its budget fails to validate.
+
+===Derivation of Costs===
+
+The costs of opcodes were determined by benchmarking on a variety of platforms.  
+
+As each block can contain 80,000 Schnorr signature checks, we used this as a reasonable upper bound for maximally slow block processing.
+
+To estimate a conservative maximum runtime for each opcode, we consider scripts with two constraints:
+1. the script size is limited by the existing weight limit of 4,000,000 units and
+2. the script can only consume the varops budget of a whole block: 10,000 * 4,000,000 (40b).
+
+The script is assumed to execute in a single thread and acts on initial stack elements that are not included in the limits for conservatism.
+
+Ideally, on each platform we tested, the worst case time for each opcode would be no worse than the Schnorr signature upper bound: i.e. the block would get no slower.  And while CHECKSIG can be batched and/or done in parallel, it also involves hashing, which is not taken into account here (the worst-case being significantly slower than the signature validations themselves).
+
+The signature cost is simply carried across from the existing [[bip-0342.mediawiki|BIP-342]] limit: 50 weight units allow you one signature.  Since each transaction gets varops budget for the entire transaction (not just the current input's witness), and each input has at least 40 bytes (160 weight), this is actually slightly more generous than the sigops budget (which was 50 + witness weight), but still limits the entire block to 80,000 signatures.
+
+===Benchmarks===
+
+The costs were validated by constructing maximally expensive scripts for every opcode (filling a full block with worst-case operands) and measuring wall-clock execution time across 14 machines spanning x86_64, ARM64, Linux, macOS, and Windows:
+
+Apple M1 Pro, Apple M2, Apple M4 Pro (macOS + Linux/Docker), AMD Ryzen 5 3600, AMD Ryzen 7 5800U, AMD Ryzen 9 9950X, Intel i5-12500, Intel i7-7700, Intel i7-8700, Intel i9-9900K, Intel N150 (Umbrel), Raspberry Pi 5.
+
+For each machine, the ratio of the GSR worst-case block time to the existing (pre-GSR) worst-case block time was computed.  A ratio below 1.0 means GSR does not introduce a new worst case.  On all 14 tested machines, the ratio is below 1.0.
+
+Without GSR, the slowest blocks are dominated by:
+* Schnorr signature validation (80,000 signatures per block)
+* Repeated hashing of 520-byte elements (3DUP + HASH256, 3DUP + RIPEMD160)
+
+With GSR enabled, the slowest blocks restricted by the varops budget depend on the machine but usually include:
+* Schnorr signature validation (80,000 signatures per block)
+* Repeated hashing of 520-byte elements (3DUP + HASH256, 3DUP + RIPEMD160)
+* Small-element multiplication (MUL on 1-byte operands)
+* Large-element left-shift with copying (2DUP + LSHIFT on 10KB elements)
+* Hashing of 1KB elements (HASH256)
+* Stack rolling at maximum depth (ROLL)
+* Large-element copying (TUCK, CAT on 100KB–2MB elements)
+
+The raw benchmark data, analysis scripts, and visualized results are available at https://github.com/jmoik/varopsData. This repository also provides instructions for running the benchmarks on your own machine.
+
+
+===Cost Categories===
+
+We divided operations into six speed categories:
+
+1. Signature operations.
+2. Hashing operations.
+3. OP_ROLL, which does a large-scale stack movement.
+4. Fast operations: comparing bytes, comparing bytes against zero, and zeroing bytes.  Empirically, these have been shown to be well-optimized.
+5. Copying bytes: slightly more expensive than fast operations due to memory allocation overhead.
+6. Everything else.
+
+Each class then has the following costs.
+
+1. Signature operations cost 500,000 (10,000 * 50) units each, this resembles the cost of the existing sigops budget.
+2. Hashing costs 50 units per byte hashed.
+3. OP_ROLL costs an additional 48 units (24 bytes per std::vector * 2 units per byte) per stack entry moved (i.e. the value of its operand).
+4. Fast operations cost 2 units per byte output.
+5. Copying operations cost 3 units per byte output.
+6. Other operations cost 4 units per byte output.
+
+===Variable Opcode Budget===
+
+We use the following annotations to indicate the derivation for each opcode:
+
+;COMPARING
+: Comparing two objects: cost = 2 per byte compared.
+;COMPARINGZERO
+: Comparing an object against zeroes: cost = 2 per byte compared.
+;ZEROING
+: Zeroing out bytes: cost = 2 per byte zeroed.
+;COPYING
+: Copying bytes: cost = 3 per byte copied.
+;LENGTHCONV
+: Converting an operand to a length value, including verifying that trailing bytes are zero: cost = 2 per byte examined.
+;SIGCHECK
+: Checking a signature is a flat cost: cost = 500,000.
+;HASH
+: cost = 50 per byte hashed.
+;ROLL
+: cost = 48 per stack element moved.
+;OTHER
+: all other operations which take a variable-length parameter: cost = 4 per byte written.
+
+Note that COMPARINGZERO is a subset of COMPARING: an implementation must examine every byte of a stack element to determine if the value is 0.  This can be done efficiently using existing comparison techniques, e.g. check the first byte, then `memcmp(first, first+1, len-1)`.
+
+Note that LENGTHCONV is used where script interprets a value as a length.  Without explicit limits on number size, such (little-endian) values might have to be examined in their entirety to ensure any trailing bytes are zero, implying a COMPARINGZERO operation after the first few bytes.
+
+The top of stack is labeled A, with successive values B, C, etc.
+
+==Example Opcodes==
+
+The following opcodes demonstrate the approach, with an analysis of how the costs apply:
+
+===Example: Control And Simple Examination Opcodes===
+
+{|
+! Opcode
+! Varops Budget Cost
+! Reason
+|-
+|OP_VERIFY
+|length(A) * 2
+|COMPARINGZERO
+|-
+|OP_NOT
+|length(A) * 2
+|COMPARINGZERO
+|-
+|OP_0NOTEQUAL
+|length(A) * 2
+|COMPARINGZERO
+|-
+|OP_EQUAL
+|If length(A) != length(B): 0, otherwise length(A) * 2
+|COMPARING
+|-
+|OP_EQUALVERIFY
+|If length(A) != length(B): 0, otherwise length(A) * 2
+|COMPARING
+|}
+
+====Rationale====
+
+OP_IF and OP_NOTIF in Tapscript require minimal values, so do not take variable length parameters, hence are not considered here.
+
+OP_EQUAL and OP_EQUALVERIFY don't have to examine any data (and the Bitcoin Core implementation does not) if the lengths are different.
+
+===Example: Stack Manipulation===
+
+{|
+! Opcode
+! Varops Budget Cost
+! Reason
+|-
+|OP_2DUP
+|(length(A) + length(B)) * 3
+|COPYING
+|-
+|OP_3DUP
+|(length(A) + length(B) + length(C)) * 3
+|COPYING
+|-
+|OP_2OVER
+|(length(C) + length(D)) * 3
+|COPYING
+|-
+|OP_IFDUP
+|length(A) * 5
+|COMPARINGZERO + COPYING
+|-
+|OP_DUP
+|length(A) * 3
+|COPYING
+|-
+|OP_OVER
+|length(B) * 3
+|COPYING
+|-
+|OP_PICK
+|length(A) * 2 + length(A-th-from-top) * 3
+|LENGTHCONV + COPYING
+|-
+|OP_TUCK
+|length(A) * 3
+|COPYING
+|-
+|OP_ROLL
+|length(A) * 2 + 48 * Value of A
+|LENGTHCONV + ROLL
+|-
+|}
+
+====Rationale====
+
+These operators copy a stack entry and write to another.  OP_IFDUP has the same worst-case cost as OP_IF + OP_DUP.
+
+OP_ROLL needs to read its operand, then move that many elements on the stack.  It is the only opcode for which the stack manipulation cost is variable (and, regretfully, non-trivial), so we need to limit it.
+
+A reasonable implementation (and the current bitcoind C++ implementation) is to use 24 bytes for each stack element (a pointer, a size and a maximum capacity), and this value works reasonably in practice.
+
+===Example: Comparison Operators===
+
+{|
+! Opcode
+! Varops Budget Cost
+|-
+|OP_BOOLAND
+|(length(A) + length(B)) * 2
+|COMPARINGZERO
+|-
+|OP_BOOLOR
+|(length(A) + length(B)) * 2
+|COMPARINGZERO
+|-
+|OP_NUMEQUAL
+|MAX(length(A), length(B)) * 2
+|COMPARING + COMPARINGZERO
+|-
+|OP_NUMEQUALVERIFY
+|MAX(length(A), length(B)) * 2
+|COMPARING + COMPARINGZERO
+|-
+|OP_NUMNOTEQUAL
+|MAX(length(A), length(B)) * 2
+|COMPARING + COMPARINGZERO
+|-
+|OP_LESSTHAN
+|MAX(length(A), length(B)) * 2
+|COMPARING + COMPARINGZERO
+|-
+|OP_GREATERTHAN
+|MAX(length(A), length(B)) * 2
+|COMPARING + COMPARINGZERO
+|-
+|OP_LESSTHANOREQUAL
+|MAX(length(A), length(B)) * 2
+|COMPARING + COMPARINGZERO
+|-
+|OP_GREATERTHANOREQUAL
+|MAX(length(A), length(B)) * 2
+|COMPARING + COMPARINGZERO
+|-
+|OP_MIN
+|MAX(length(A), length(B)) * 4
+|OTHER
+|-
+|OP_MAX
+|MAX(length(A), length(B)) * 4
+|OTHER
+|-
+|OP_WITHIN
+|(MAX(length(C), length(B)) + MAX(length(C), length(A))) * 2
+|COMPARING + COMPARINGZERO
+|}
+
+====Rationale====
+
+Numerical comparison in little-endian numbers involves a byte-by-byte comparison, then if one is longer, checking that the remainder is all zero bytes.
+
+However, OP_MAX and OP_MIN also normalize their result, which means they can't use the optimized comparison routine but must instead track the final non-zero byte to perform truncation.
+
+===Example: Hash Operators===
+
+{|
+! Opcode
+! Varops Budget Cost
+| Reason
+|-
+|OP_SHA256
+|(Length of the operand) * 50
+|HASH
+|-
+|OP_HASH160
+|(Length of the operand) * 50
+|HASH
+|-
+|OP_HASH256
+|(Length of the operand) * 50
+|HASH
+|}
+
+====Rationale====
+
+SHA256 has been well-optimized for current hardware, as it is already critical to Bitcoin's operation.  Additional once-off steps such as the final SHA round, and RIPEMD or a second SHA256 are not proportional to the input, so are not included in the cost model.
+
+A model for other hash operations (OP_SHA1, OP_RIPEMD160) is possible, but we have not done so.  They are not generally optimized, and if they were permitted on large inputs, this would have to be done.
+
+==Reference Implementation==
+
+Work in progress:
+
+	https://github.com/jmoik/bitcoin/tree/gsr
+
+==Changelog==
+
+0.1.0: 2025-09-27: first public posting
+0.2.0: 2025-02-21: increase in cost for hashing and copying based on benchmark results.
+
+==Thanks==
+
+This BIP would not exist without the thoughtful contributions of coders who considered all the facets carefully and thoroughly, and also my inspirational wife Alex and my kids who have been tirelessly supportive of my esoteric-seeming endeavors such as this!
+
+In alphabetical order:
+- Anthony Towns
+- Brandon Black (aka Reardencode)
+- John Light
+- Jonas Nick
+- Rijndael (aka rot13maxi)
+- Steven Roose
+- FIXME: your name here!
+
+== Footnotes ==
+
+<references />


### PR DESCRIPTION
- Replace Required Stack Elements and Varops Reason columns with Input/Output columns and inline cost annotations
- Condense definitions to concise abstract descriptions
- Add introductory paragraph for bitwise opcodes explaining zero-extension of shorter operands
- Use mediawiki ordered list syntax (#) instead of manual numbering
- Clarify rationale for OP_OR/OP_XOR cost stopping early
- Replace "nee" with "formerly" for OP_UPSHIFT/OP_DOWNSHIFT
- Use consistent "minimal form" / "normalize" terminology
- Fix Division Cost heading level mismatch